### PR TITLE
 [DO NOT MERGE] GTK: Fix early exit from `wxDropSource::DoDragDrop`

### DIFF
--- a/include/wx/dnd.h
+++ b/include/wx/dnd.h
@@ -95,7 +95,6 @@ public:
     // give the default feedback
     virtual bool GiveFeedback(wxDragResult WXUNUSED(effect)) { return false; }
 
-protected:
     const wxCursor& GetCursor(wxDragResult res) const
     {
         if ( res == wxDragCopy )
@@ -105,7 +104,8 @@ protected:
         else
             return m_cursorStop;
     }
-
+	
+protected:
     // the data we're dragging
     wxDataObject *m_data;
 

--- a/include/wx/generic/headerctrlg.h
+++ b/include/wx/generic/headerctrlg.h
@@ -52,6 +52,12 @@ protected:
 
 
 private:
+	enum class Region{
+		NoWhere,
+		LeftHalf,
+		RightHalf,
+		Separator
+	};
     // implement base class pure virtuals
     virtual void DoSetCount(unsigned int count) wxOVERRIDE;
     virtual unsigned int DoGetCount() const wxOVERRIDE;
@@ -96,11 +102,14 @@ private:
     // position is near the divider at the right end of this column (notice
     // that this means that we return column 0 even if the position is over
     // column 1 but close enough to the divider separating it from column 0)
-    unsigned int FindColumnAtPoint(int x, bool *onSeparator = NULL) const;
+    unsigned int FindColumnAtPoint(int x, Region& pos_region) const;
 
     // return the result of FindColumnAtPoint() if it is a valid column,
     // otherwise the index of the last (rightmost) displayed column
-    unsigned int FindColumnClosestToPoint(int xPhysical) const;
+    unsigned int FindColumnClosestToPoint(int xPhysical, Region& pos_region) const;
+
+    unsigned int FindColumnAfter(const unsigned int column_idx) const;
+    unsigned int FindColumnBefore(const unsigned int column_idx) const;
 
     // return true if a drag resizing operation is currently in progress
     bool IsResizing() const;

--- a/include/wx/osx/cocoa/private/dnd.h
+++ b/include/wx/osx/cocoa/private/dnd.h
@@ -1,0 +1,36 @@
+#include "wx/wxprec.h"
+
+#if wxUSE_DRAG_AND_DROP || wxUSE_CLIPBOARD
+
+#ifndef WX_PRECOMP
+#include "wx/object.h"
+#endif
+
+#include "wx/dnd.h"
+
+#include "wx/osx/private.h"
+#include "wx/osx/private/datatransfer.h"
+
+@interface DropSourceDelegate : NSObject<NSDraggingSource>
+{
+    BOOL dragFinished;
+    int resultCode;
+    wxDropSource* impl;
+
+    // Flags for drag and drop operations (wxDrag_* ).
+    int m_dragFlags;
+    NSImage* m_copy_cursor;
+    NSImage* m_move_cursor;
+    NSImage* m_none_cursor;
+}
+
+- (void)setImplementation:(nonnull wxDropSource *)dropSource flags:(int)flags;
+- (BOOL)finished;
+- (NSDragOperation)code;
+- (NSDragOperation)draggingSession:(nonnull NSDraggingSession *)session sourceOperationMaskForDraggingContext:(NSDraggingContext)context;
+- (void)draggedImage:(nonnull NSImage *)anImage movedTo:(NSPoint)aPoint;
+- (void)draggedImage:(nonnull NSImage *)anImage endedAt:(NSPoint)aPoint operation:(NSDragOperation)operation;
+- (nullable NSImage*)cursorForStatus:(wxDragResult)status;
+@end
+
+#endif

--- a/include/wx/window.h
+++ b/include/wx/window.h
@@ -49,6 +49,12 @@
     #define wxUSE_MENUS_NATIVE wxUSE_MENUS
 #endif // __WXUNIVERSAL__/!__WXUNIVERSAL__
 
+#ifdef __WXGTK__
+namespace CMExtension {
+    extern bool g_need_traditional_scrollbar;
+}
+#endif
+
 // ----------------------------------------------------------------------------
 // forward declarations
 // ----------------------------------------------------------------------------

--- a/src/common/popupcmn.cpp
+++ b/src/common/popupcmn.cpp
@@ -451,19 +451,23 @@ void wxPopupTransientWindow::OnIdle(wxIdleEvent& event)
 
     if (IsShown() && m_child)
     {
-        // Store the last mouse position to minimize the number of calls to
-        // wxFindWindowAtPoint() which are quite expensive.
+        // Store the last mouse position
         static wxPoint s_posLast;
         const wxPoint pos = wxGetMousePosition();
         if ( pos != s_posLast )
         {
             s_posLast = pos;
-
-            wxWindow* const winUnderMouse = wxFindWindowAtPoint(pos);
+			
+            // DO NOT use wxFindWindowAtPoint() because if there're multiple top level windows,
+            // it will 'Find the deepest window at the given mouse position in screen coordinates', 
+            // which is not the right one for this logic.
+            auto screen_rect = GetScreenRect();
+            const auto mouse_within_me = (pos.x >= screen_rect.GetTopLeft().x and pos.y >= screen_rect.GetTopLeft().y and
+                pos.x <= screen_rect.GetBottomRight().x and pos.y <= screen_rect.GetBottomRight().y);
 
             // We release the mouse capture while the mouse is inside the popup
             // itself to allow using it normally with the controls inside it.
-            if ( wxGetTopLevelParent(winUnderMouse) == this )
+            if ( mouse_within_me )
             {
                 if ( m_child->HasCapture() )
                 {

--- a/src/generic/headerctrlg.cpp
+++ b/src/generic/headerctrlg.cpp
@@ -516,7 +516,7 @@ bool wxHeaderCtrl::EndReordering(int xPhysical)
     {
         return false;
     }
-    if ( static_cast<int>(colNew) != colOld )
+    if ( static_cast<int>(colNew) != colOld && dropped_region != Region::NoWhere )
     {
         wxHeaderCtrlEvent event(wxEVT_HEADER_END_REORDER, GetId());
         event.SetEventObject(this);

--- a/src/generic/headerctrlg.cpp
+++ b/src/generic/headerctrlg.cpp
@@ -546,7 +546,7 @@ bool wxHeaderCtrl::EndReordering(int xPhysical)
             event.SetNewOrder(new_pos);
             
             //printf("Move col %d to %d, pos to %d\n", colOld, colNew, new_pos);
-            if ( GetEventHandler()->ProcessEvent(event) || event.IsAllowed() )
+            if ( !GetEventHandler()->ProcessEvent(event) || event.IsAllowed() )
             {
                 // do reorder the columns
                 DoMoveCol(colOld, new_pos);

--- a/src/generic/headerctrlg.cpp
+++ b/src/generic/headerctrlg.cpp
@@ -350,6 +350,7 @@ void wxHeaderCtrl::StartOrContinueResizing(unsigned int col, int xPhysical)
         //else: we had already done the above when we started
 
     }
+    RefreshColsAfter(col);
 }
 
 void wxHeaderCtrl::EndResizing(int xPhysical)

--- a/src/gtk/dnd.cpp
+++ b/src/gtk/dnd.cpp
@@ -852,13 +852,11 @@ wxDragResult wxDropSource::DoDragDrop(int flags)
     if (g_blockEventsOnDrag)
         return wxDragNone;
 
+#if 0 // behaves bad for Coremail Air Client, need to investigate whether the early exiting is correct
     // don't start dragging if no button is down
     if (g_lastButtonNumber == 0)
         return wxDragNone;
-
-    // we can only start a drag after a mouse event
-    if (g_lastMouseEvent == NULL)
-        return wxDragNone;
+#endif
 
     GTKConnectDragSignals();
     wxON_BLOCK_EXIT_OBJ0(*this, wxDropSource::GTKDisconnectDragSignals);

--- a/src/gtk/window.cpp
+++ b/src/gtk/window.cpp
@@ -4866,7 +4866,15 @@ void wxWindowGTK::SetFocus()
     // But avoid activating if tlw is not yet shown, as that will
     // cause it to be immediately shown.
     GtkWidget* tlw = gtk_widget_get_ancestor(m_widget, GTK_TYPE_WINDOW);
-    if (tlw && gtk_widget_get_visible(tlw) && !gtk_window_is_active(GTK_WINDOW(tlw)))
+    if (tlw && gtk_widget_get_visible(tlw))
+		// we don't need to consider whether the tlw is active or not,
+		// for these two reasons:
+		// 1. if the gtk_window_is_active(tlw), gtk_window_preset() don't harm anyway;
+		// 2. when foreign XWindow embedded(not via GtkPlug), maybe use XWindow controlled by GDK as their parent,
+		//    for example, a CEF browser window(which is now an XWindow) take ours as parent,
+		//    our tlw active state maybe altered(when CEF window take the keyboard focus) and unknown to us.
+		//    i.e. gtk_window_is_active(tlw) may still true while the focus is already taken by the CEF window.
+		//	  we need to force to bring up our tlw to the user at this moment.
         gtk_window_present(GTK_WINDOW(tlw));
 
     GtkWidget *widget = m_wxwindow ? m_wxwindow : m_focusWidget;

--- a/src/gtk/window.cpp
+++ b/src/gtk/window.cpp
@@ -72,6 +72,10 @@ typedef guint KeySym;
     #define PANGO_VERSION_CHECK(a,b,c) 0
 #endif
 
+namespace CMExtension {
+    bool g_need_traditional_scrollbar = false;
+}
+
 //-----------------------------------------------------------------------------
 // documentation on internals
 //-----------------------------------------------------------------------------
@@ -2764,6 +2768,9 @@ void wxWindowGTK::GTKCreateScrolledWindowWith(GtkWidget* view)
     m_widget = gtk_scrolled_window_new( NULL, NULL );
 
     GtkScrolledWindow *scrolledWindow = GTK_SCROLLED_WINDOW(m_widget);
+	
+    if (CMExtension::g_need_traditional_scrollbar)
+        g_object_set(scrolledWindow, "overlay-scrolling", false, NULL);
 
     // There is a conflict with default bindings at GTK+
     // level between scrolled windows and notebooks both of which want to use

--- a/src/gtk/window.cpp
+++ b/src/gtk/window.cpp
@@ -2273,7 +2273,7 @@ gtk_window_leave_callback( GtkWidget*,
         win->GTKUpdateCursor();
 
     // Event was emitted after an ungrab
-    if (gdk_event->mode != GDK_CROSSING_NORMAL) return FALSE;
+    if (gdk_event->mode != GDK_CROSSING_NORMAL && gdk_event->mode != GDK_CROSSING_GRAB && gdk_event->mode != GDK_CROSSING_GTK_GRAB) return FALSE;
 
     wxMouseEvent event( wxEVT_LEAVE_WINDOW );
     InitMouseEvent(win, event, gdk_event);

--- a/src/osx/cocoa/dnd.mm
+++ b/src/osx/cocoa/dnd.mm
@@ -486,11 +486,16 @@ typedef NSString* NSPasteboardType;
 wxDragResult wxDropSource::DoDragDrop(int flags)
 {
     wxASSERT_MSG( m_data, wxT("Drop source: no data") );
-
+    static bool g_in_dnd = false;
+	
     wxDragResult result = wxDragNone;
     if ((m_data == NULL) || (m_data->GetFormatCount() == 0))
         return result;
-
+	
+	if (g_in_dnd)
+        return wxDragNone;
+    
+    g_in_dnd = true;
     NSView* view = m_window->GetPeer()->GetWXWidget();
     if (view)
     {
@@ -555,8 +560,8 @@ wxDragResult wxDropSource::DoDragDrop(int flags)
 
         gCurrentSource = NULL;
     }
-
-
+	
+	g_in_dnd = false;
     return result;
 }
 

--- a/src/osx/cocoa/dnd.mm
+++ b/src/osx/cocoa/dnd.mm
@@ -522,8 +522,21 @@ wxDragResult wxDropSource::DoDragDrop(int flags)
     if (view)
     {
         NSEvent* theEvent = (NSEvent*)wxTheApp->MacGetCurrentEvent();
-        wxASSERT_MSG(theEvent, "DoDragDrop must be called in response to a mouse down or drag event.");
-
+        // relax the constraint set for DoDragDrop().
+        // if the user start DnD something from a frame rendered by CEF or similar framework, it should be perfectly valid.
+        if (theEvent == nil){
+            NSPoint mouse_location = [NSEvent mouseLocation];
+            theEvent = [NSEvent mouseEventWithType:NSEventTypeLeftMouseDragged 
+                location:mouse_location
+                modifierFlags:0
+                timestamp: 0
+                windowNumber: [NSWindow windowNumberAtPoint:mouse_location belowWindowWithWindowNumber:0]
+                context:nil
+                eventNumber: 0
+                clickCount: 0
+                pressure: 1.0];
+        }
+		
         gCurrentSource = this;
 
         DropSourceDelegate* delegate = [[DropSourceDelegate alloc] init];

--- a/src/osx/cocoa/dnd.mm
+++ b/src/osx/cocoa/dnd.mm
@@ -17,6 +17,7 @@
 #endif
 
 #include "wx/dnd.h"
+#include "wx/osx/cocoa/private/dnd.h"
 #include "wx/clipbrd.h"
 #include "wx/filename.h"
 
@@ -268,24 +269,6 @@ wxDragResult NSDragOperationToWxDragResult(NSDragOperation code)
     return wxDragNone;
 }
 
-@interface DropSourceDelegate : NSObject<NSDraggingSource>
-{
-    BOOL dragFinished;
-    int resultCode;
-    wxDropSource* impl;
-
-    // Flags for drag and drop operations (wxDrag_* ).
-    int m_dragFlags;
-}
-
-- (void)setImplementation:(wxDropSource *)dropSource flags:(int)flags;
-- (BOOL)finished;
-- (NSDragOperation)code;
-- (NSDragOperation)draggingSession:(nonnull NSDraggingSession *)session sourceOperationMaskForDraggingContext:(NSDraggingContext)context;
-- (void)draggedImage:(NSImage *)anImage movedTo:(NSPoint)aPoint;
-- (void)draggedImage:(NSImage *)anImage endedAt:(NSPoint)aPoint operation:(NSDragOperation)operation;
-@end
-
 @implementation DropSourceDelegate
 
 - (id)init
@@ -296,6 +279,9 @@ wxDragResult NSDragOperationToWxDragResult(NSDragOperation code)
         resultCode = NSDragOperationNone;
         impl = 0;
         m_dragFlags = wxDrag_CopyOnly;
+        m_copy_cursor = nil;
+        m_move_cursor = nil;
+        m_none_cursor = nil;
     }
     return self;
 }
@@ -397,6 +383,42 @@ wxDragResult NSDragOperationToWxDragResult(NSDragOperation code)
     dragFinished = YES;
 }
 
+- (NSImage*)cursorForStatus:(wxDragResult)status
+{
+    NSImage* cursor_img = nil;
+    switch(status){
+    case wxDragCopy:
+        cursor_img = m_copy_cursor;
+        break;
+    case wxDragMove:
+        cursor_img = m_move_cursor;
+        break;
+    default:
+        cursor_img = m_none_cursor;
+        break;
+    }
+    if (cursor_img != nil)
+        return cursor_img;
+
+	wxCursor indicate_cursor = impl->GetCursor(status);
+	
+	if (indicate_cursor.IsOk()) {
+		NSCursor *cursor = (NSCursor*)indicate_cursor.GetHCURSOR();
+		cursor_img = [[cursor image] retain];
+        switch(status){
+        case wxDragCopy:
+            m_copy_cursor = cursor_img;
+            break;
+        case wxDragMove:
+            m_move_cursor = cursor_img;
+            break;
+        default:
+            m_none_cursor = cursor_img;
+            break;
+        }
+	}
+	return cursor_img;
+}
 @end
 
 wxDropTarget::wxDropTarget( wxDataObject *data )

--- a/src/osx/cocoa/evtloop.mm
+++ b/src/osx/cocoa/evtloop.mm
@@ -434,7 +434,15 @@ void wxModalEventLoop::OSXDoRun()
     if ( m_modalWindow )
     {
         BeginModalSession(m_modalWindow);
-        wxCFEventLoop::OSXDoRun();
+		while(true){
+			try {
+				wxCFEventLoop::OSXDoRun();
+				break;
+			}
+			catch(...){
+				printf("wxModalEventLoop::OSXDoRun caught unknown exception\n");
+			}
+		}
         EndModalSession();
     }
     else

--- a/src/osx/cocoa/evtloop.mm
+++ b/src/osx/cocoa/evtloop.mm
@@ -380,7 +380,7 @@ void wxGUIEventLoop::WakeUp()
         NSEvent *event = [NSEvent otherEventWithType:NSApplicationDefined 
                                         location:NSMakePoint(0.0, 0.0) 
                                    modifierFlags:0 
-                                       timestamp:0 
+                                       timestamp:[[NSProcessInfo processInfo] systemUptime] 
                                     windowNumber:0 
                                          context:nil
                                          subtype:0 data1:0 data2:0]; 

--- a/src/osx/cocoa/utils.mm
+++ b/src/osx/cocoa/utils.mm
@@ -421,7 +421,7 @@ bool wxApp::CallOnInit()
         NSEvent *event = [NSEvent otherEventWithType:NSApplicationDefined
                                     location:NSMakePoint(0.0, 0.0)
                                modifierFlags:0
-                                   timestamp:0
+                                   timestamp:[[NSProcessInfo processInfo] systemUptime]
                                 windowNumber:0
                                      context:nil
                                      subtype:0 data1:0 data2:0];

--- a/src/osx/cocoa/utils.mm
+++ b/src/osx/cocoa/utils.mm
@@ -409,7 +409,7 @@ bool wxApp::CallOnInit()
         NSEvent *event = [NSEvent otherEventWithType:NSApplicationDefined
                                     location:NSMakePoint(0.0, 0.0)
                                modifierFlags:0
-                                   timestamp:0
+                                   timestamp:[[NSProcessInfo processInfo] systemUptime]
                                 windowNumber:0
                                      context:nil
                                      subtype:0 data1:0 data2:0];

--- a/src/osx/cocoa/window.mm
+++ b/src/osx/cocoa/window.mm
@@ -37,6 +37,9 @@
 #if wxUSE_DRAG_AND_DROP
     #include "wx/dnd.h"
     #include "wx/clipbrd.h"
+    #ifdef __WXOSX_MAC__
+    #include "wx/osx/cocoa/private/dnd.h"
+    #endif
 #endif
 
 #if wxUSE_TOOLTIPS
@@ -1374,6 +1377,22 @@ unsigned int wxOnDraggingEnteredOrUpdated(wxWidgetCocoaImpl* viewImpl,
         default :
             break;
     }
+	if (!entered){
+		NSView* the_view = viewImpl->GetWXWidget();
+		[sender enumerateDraggingItemsWithOptions:NSDraggingItemEnumerationConcurrent forView:the_view 
+			classes:[NSArray arrayWithObject:[NSPasteboardItem class]] searchOptions:nil 
+			usingBlock:^(NSDraggingItem *draggingItem, NSInteger idx, BOOL *stop) {
+                           wxUnusedVar(idx);
+						   NSRect theFrame = draggingItem.draggingFrame;
+						   DropSourceDelegate* drop_src_delegate = sender.draggingSource;
+						   NSImage* newDragImage = [drop_src_delegate cursorForStatus:result];
+                           if (newDragImage != nil){
+                               NSRect newFrame = NSMakeRect(theFrame.origin.x, theFrame.origin.y, newDragImage.size.width, newDragImage.size.height);
+						       [draggingItem setDraggingFrame:newFrame contents:newDragImage];
+                           }
+						   *stop = NO;
+					   }];	
+	}
     return nsresult;
 }
 

--- a/src/osx/cocoa/window.mm
+++ b/src/osx/cocoa/window.mm
@@ -36,6 +36,9 @@
 #if wxUSE_DRAG_AND_DROP
     #include "wx/dnd.h"
     #include "wx/clipbrd.h"
+    #ifdef __WXOSX_MAC__
+    #include "wx/osx/cocoa/private/dnd.h"
+    #endif
 #endif
 
 #if wxUSE_TOOLTIPS
@@ -1370,6 +1373,22 @@ unsigned int wxOnDraggingEnteredOrUpdated(wxWidgetCocoaImpl* viewImpl,
         default :
             break;
     }
+	if (!entered){
+		NSView* the_view = viewImpl->GetWXWidget();
+		[sender enumerateDraggingItemsWithOptions:NSDraggingItemEnumerationConcurrent forView:the_view 
+			classes:[NSArray arrayWithObject:[NSPasteboardItem class]] searchOptions:nil 
+			usingBlock:^(NSDraggingItem *draggingItem, NSInteger idx, BOOL *stop) {
+                           wxUnusedVar(idx);
+						   NSRect theFrame = draggingItem.draggingFrame;
+						   DropSourceDelegate* drop_src_delegate = sender.draggingSource;
+						   NSImage* newDragImage = [drop_src_delegate cursorForStatus:result];
+                           if (newDragImage != nil){
+                               NSRect newFrame = NSMakeRect(theFrame.origin.x, theFrame.origin.y, newDragImage.size.width, newDragImage.size.height);
+						       [draggingItem setDraggingFrame:newFrame contents:newDragImage];
+                           }
+						   *stop = NO;
+					   }];	
+	}
     return nsresult;
 }
 

--- a/src/osx/webview_webkit.mm
+++ b/src/osx/webview_webkit.mm
@@ -618,6 +618,10 @@ void wxWebViewWebKit::RegisterHandler(wxSharedPtr<wxWebViewHandler> handler)
 
 - (BOOL)performKeyEquivalent:(NSEvent *)event
 {
+    if (self.window.firstResponder != self) 
+    {
+        return NO;
+    }
     if ([event modifierFlags] & NSCommandKeyMask)
     {
         switch ([event.characters characterAtIndex:0])

--- a/src/ribbon/buttonbar.cpp
+++ b/src/ribbon/buttonbar.cpp
@@ -1066,7 +1066,6 @@ void wxRibbonButtonBar::MakeLayouts()
         //               small buttons small, stacked vertically
         wxRibbonButtonBarLayout* layout = new wxRibbonButtonBarLayout;
         wxPoint cursor(0, 0);
-        layout->overall_size.SetHeight(0);
         for(btn_i = 0; btn_i < btn_count; ++btn_i)
         {
             wxRibbonButtonBarButtonBase* button = m_buttons.Item(btn_i);
@@ -1102,8 +1101,7 @@ void wxRibbonButtonBar::MakeLayouts()
             }
             layout->buttons.Add(instance);
         }
-        layout->overall_size.SetHeight(available_height);
-        layout->overall_size.SetWidth(cursor.x + stacked_width);
+        layout->CalculateOverallSize();
         m_layouts.Add(layout);
     }
     if(btn_count >= 2)


### PR DESCRIPTION
Missing of mouse event is not an error.

~It's not very clear whether `g_lastButtonNumber` is needed to be correct.~ It is needed. So we can't not directly remove the condition.